### PR TITLE
Add nix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /.idea
 
 /test-svgs
+
+result

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ With Nix using flakes, add `inputs.hyprswitch.packages.x86_64-linux.default` to 
 Once the binary is installed, you can modify your `~/.config/hypr/hyprland.conf`.
 
 The script accepts these parameters [cli](./src/cli.rs):.
-
 - Sorting related
-
   - `--reverse`/`-r` Reverse the order of windows / switch backwards
   - `--filter-same-class`/`-s` Only show/switch between windows that have the same class/type as the currently focused window
   - `--filter-current-workspace`/`-w` Only show/switch between windows that are on the same workspace as the currently focused window
@@ -42,7 +40,6 @@ The script accepts these parameters [cli](./src/cli.rs):.
   - `--ignore-monitors` Sort all windows on matching workspaces on monitors like [one big monitor](#--ignore-monitors), [workspaces must have offset of 10 for each monitor](#ignore-monitors-flag)
 
 - GUI related
-
   - `--daemon` Starts as daemon, creates socket server and GUI, sends Command to the daemon if already running
   - `--stop-daemon` Stops the daemon, sends stop to socket server, doesn't execute current window switch, executes the command to switch window if `--switch-on-close` is true
   - `--do-initial-execute` Also execute the initial command when starting the daemon
@@ -55,13 +52,10 @@ The script accepts these parameters [cli](./src/cli.rs):.
 - `-v` Increase the verbosity level
 
 #### Here are some examples:
-
 (Modify the $... variables to your liking)
 
 ### No-GUI Config
-
 Just use 2 keybindings to switch to 'next' or 'previous' window
-
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -72,9 +66,7 @@ bind=$modifier $reverse, $key, exec, hyprswitch -r
 ```
 
 ### No-GUI sort-recent Config
-
 Just use 1 keybinding to switch to previously focused application
-
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -84,9 +76,7 @@ bind=$modifier, $key, exec, hyprswitch --sort-recent
 ```
 
 ### Same class No-GUI Config
-
 Just use 2 keybindings to switch to 'next' or 'previous' window of same class/type
-
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -97,9 +87,7 @@ bind=$modifier $reverse, $key, exec, hyprswitch -s -r
 ```
 
 ### GUI Config
-
 Press $modifier + $key to open the GUI, use mouse to click on window
-
 ```ini
 $key = TAB
 $modifier = SUPER
@@ -114,15 +102,13 @@ bindr=$modifier, $switch_release, exec, hyprswitch --stop-daemon
 bindrn=,escape, exec, pkill hyprswitch
 ```
 
+
 ### GUI + Keyboard Config
-
 Complex Config with submap to allow for many different keybindings when opening hyprswitch (run `hyprctl dispatch submap reset` if stuck in switch submap)
-
-- Press (and hold) $modifier + $key to open the GUI and switch trough window
+- Press (and hold) $modifier + $key to open the GUI and switch trough window 
 - Release $key and press 3 to switch to the third next window
 - Release $key and press/hold $reverse + $key to traverse in reverse order
 - Release $modifier ($modifier_release) to execute the switch and close the gui
-
 ```ini
 $key = TAB
 $modifier = ALT
@@ -165,6 +151,7 @@ bindr=,escape, exec, pkill hyprswitch
 bindr=,escape, submap, reset
 submap=reset
 ```
+
 
 # Rust Features
 
@@ -230,9 +217,7 @@ the first monitor is 1 to allow the scrip to map the correct workspaces together
 this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.org/Configuring/Workspace-Rules/)
 
 ### `--ignore-workspaces`
-
-- Order without `--ignore-workspaces`
-
+- Order without `--ignore-workspaces` 
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11
@@ -245,9 +230,7 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
  7  +------+  +------+ | +------+  +------+  |  +---------+  +---+ | +------+  +------+
     1      2  3      4   1      2  3      4     5      6  7  8   9   5      6  7   8  9
 ```
-
-- Order with `--ignore-workspaces`
-
+- Order with `--ignore-workspaces` 
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10         Workspace 11
@@ -262,9 +245,7 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
 ```
 
 ### `--ignore-monitors`
-
-- Order without `--ignore-monitors`
-
+- Order without `--ignore-monitors` 
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11
@@ -277,9 +258,7 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
  7  +------+  +------+ | +------+  +------+  |  +---------+  +---+ | +------+  +------+
     1      2  3      4   1      2  3      4     5      6  7  8   9   5      6  7   8  9
 ```
-
-- Order with `--ignore-monitors`
-
+- Order with `--ignore-monitors` 
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11

--- a/README.md
+++ b/README.md
@@ -21,12 +21,16 @@ Subsequent calls to the script (with the `--daemon` flag) will send the command 
 
 `paru -S hyprswitch` / `yay -S hyprswitch`
 
+With Nix using flakes, add `inputs.hyprswitch.packages.x86_64-linux.default` to your packages list with this repo as an input.
+
 # Usage
 
 Once the binary is installed, you can modify your `~/.config/hypr/hyprland.conf`.
 
 The script accepts these parameters [cli](./src/cli.rs):.
+
 - Sorting related
+
   - `--reverse`/`-r` Reverse the order of windows / switch backwards
   - `--filter-same-class`/`-s` Only show/switch between windows that have the same class/type as the currently focused window
   - `--filter-current-workspace`/`-w` Only show/switch between windows that are on the same workspace as the currently focused window
@@ -38,6 +42,7 @@ The script accepts these parameters [cli](./src/cli.rs):.
   - `--ignore-monitors` Sort all windows on matching workspaces on monitors like [one big monitor](#--ignore-monitors), [workspaces must have offset of 10 for each monitor](#ignore-monitors-flag)
 
 - GUI related
+
   - `--daemon` Starts as daemon, creates socket server and GUI, sends Command to the daemon if already running
   - `--stop-daemon` Stops the daemon, sends stop to socket server, doesn't execute current window switch, executes the command to switch window if `--switch-on-close` is true
   - `--do-initial-execute` Also execute the initial command when starting the daemon
@@ -50,10 +55,13 @@ The script accepts these parameters [cli](./src/cli.rs):.
 - `-v` Increase the verbosity level
 
 #### Here are some examples:
+
 (Modify the $... variables to your liking)
 
 ### No-GUI Config
+
 Just use 2 keybindings to switch to 'next' or 'previous' window
+
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -64,7 +72,9 @@ bind=$modifier $reverse, $key, exec, hyprswitch -r
 ```
 
 ### No-GUI sort-recent Config
+
 Just use 1 keybinding to switch to previously focused application
+
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -74,7 +84,9 @@ bind=$modifier, $key, exec, hyprswitch --sort-recent
 ```
 
 ### Same class No-GUI Config
+
 Just use 2 keybindings to switch to 'next' or 'previous' window of same class/type
+
 ```ini
 $key = TAB
 $modifier = CTRL
@@ -85,7 +97,9 @@ bind=$modifier $reverse, $key, exec, hyprswitch -s -r
 ```
 
 ### GUI Config
+
 Press $modifier + $key to open the GUI, use mouse to click on window
+
 ```ini
 $key = TAB
 $modifier = SUPER
@@ -100,13 +114,15 @@ bindr=$modifier, $switch_release, exec, hyprswitch --stop-daemon
 bindrn=,escape, exec, pkill hyprswitch
 ```
 
-
 ### GUI + Keyboard Config
+
 Complex Config with submap to allow for many different keybindings when opening hyprswitch (run `hyprctl dispatch submap reset` if stuck in switch submap)
-- Press (and hold) $modifier + $key to open the GUI and switch trough window 
+
+- Press (and hold) $modifier + $key to open the GUI and switch trough window
 - Release $key and press 3 to switch to the third next window
 - Release $key and press/hold $reverse + $key to traverse in reverse order
 - Release $modifier ($modifier_release) to execute the switch and close the gui
+
 ```ini
 $key = TAB
 $modifier = ALT
@@ -149,7 +165,6 @@ bindr=,escape, exec, pkill hyprswitch
 bindr=,escape, submap, reset
 submap=reset
 ```
-
 
 # Rust Features
 
@@ -215,7 +230,9 @@ the first monitor is 1 to allow the scrip to map the correct workspaces together
 this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.org/Configuring/Workspace-Rules/)
 
 ### `--ignore-workspaces`
-- Order without `--ignore-workspaces` 
+
+- Order without `--ignore-workspaces`
+
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11
@@ -228,7 +245,9 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
  7  +------+  +------+ | +------+  +------+  |  +---------+  +---+ | +------+  +------+
     1      2  3      4   1      2  3      4     5      6  7  8   9   5      6  7   8  9
 ```
-- Order with `--ignore-workspaces` 
+
+- Order with `--ignore-workspaces`
+
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10         Workspace 11
@@ -243,7 +262,9 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
 ```
 
 ### `--ignore-monitors`
-- Order without `--ignore-monitors` 
+
+- Order without `--ignore-monitors`
+
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11
@@ -256,7 +277,9 @@ this can be configured in `~/.config/hypr/hyprland.conf` (https://wiki.hyprland.
  7  +------+  +------+ | +------+  +------+  |  +---------+  +---+ | +------+  +------+
     1      2  3      4   1      2  3      4     5      6  7  8   9   5      6  7   8  9
 ```
-- Order with `--ignore-monitors` 
+
+- Order with `--ignore-monitors`
+
 ```
                    Monitor 1                                   Monitor 2
        Workspace 0           Workspace 1           Workspace 10          Workspace 11

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1711588226,
+        "narHash": "sha256-nd7goEu+nH/WZ/uCxvbWzSYqzZZn25kWTeKfANOhCjU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7232f19f7fb710e3554cafaa9d8e93cff8273b59",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+  };
+  outputs = inputs:
+    with inputs; let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs {
+        inherit system;
+      };
+    in {
+      packages.x86_64-linux = rec {
+        default = hyprswitch;
+        hyprswitch = pkgs.callPackage ./package.nix {};
+      };
+      # devShells.x86_64-linux = {
+      #   default = pkgs.callPackage ./shell.nix {};
+      # };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,10 @@
         default = hyprswitch;
         hyprswitch = pkgs.callPackage ./package.nix {};
       };
+      packages.aarch64-linux = rec {
+        default = hyprswitch;
+        hyprswitch = pkgs.callPackage ./package.nix {};
+      };
       # devShells.x86_64-linux = {
       #   default = pkgs.callPackage ./shell.nix {};
       # };

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  pkgs,
+  pkg-config,
+  rustPlatform,
+  makeWrapper,
+}:
+rustPlatform.buildRustPackage rec {
+  name = "hyprswitch";
+  version = "1.2.2";
+
+  src = lib.cleanSource ./.;
+
+  cargoHash = "sha256-LiH7OqQL7te1GVF3qfYVRQpAhQmsVGtgwhKhZorQp2k=";
+
+  nativeBuildInputs = [
+    pkg-config
+    makeWrapper
+  ];
+
+  buildInputs = with pkgs; [
+    glib
+    gtk4
+    gtk4-layer-shell
+  ];
+
+  postInstall = ''
+    wrapProgram $out/bin/${name}
+  '';
+
+  meta = with lib; {
+    description = "Graphical app switcher for hyprland";
+    homepage = "https://github.com/H3rmt/hyprswitch";
+    license = licenses.mit;
+  };
+}

--- a/package.nix
+++ b/package.nix
@@ -4,36 +4,35 @@
   pkg-config,
   rustPlatform,
   makeWrapper,
-}:
-let
-  meta = (builtins.fromTOML ./Cargo.toml).package;
+}: let
+  package = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).package;
 in
-rustPlatform.buildRustPackage rec {
-  name = meta.name;
-  version = meta.version;
+  rustPlatform.buildRustPackage rec {
+    name = package.name;
+    version = package.version;
 
-  src = lib.cleanSource ./.;
+    src = lib.cleanSource ./.;
 
-  cargoHash = "sha256-LiH7OqQL7te1GVF3qfYVRQpAhQmsVGtgwhKhZorQp2k=";
+    cargoLock.lockFile = ./Cargo.lock;
 
-  nativeBuildInputs = [
-    pkg-config
-    makeWrapper
-  ];
+    nativeBuildInputs = [
+      pkg-config
+      makeWrapper
+    ];
 
-  buildInputs = with pkgs; [
-    glib
-    gtk4
-    gtk4-layer-shell
-  ];
+    buildInputs = with pkgs; [
+      glib
+      gtk4
+      gtk4-layer-shell
+    ];
 
-  postInstall = ''
-    wrapProgram $out/bin/${name}
-  '';
+    postInstall = ''
+      wrapProgram $out/bin/${name}
+    '';
 
-  meta = with lib; {
-    description = meta.description;
-    homepage = meta.repository;
-    license = licenses.mit;
-  };
-}
+    meta = with lib; {
+      description = package.description;
+      homepage = package.repository;
+      license = licenses.mit;
+    };
+  }

--- a/package.nix
+++ b/package.nix
@@ -5,9 +5,12 @@
   rustPlatform,
   makeWrapper,
 }:
+let
+  meta = (builtins.fromTOML ./Cargo.toml).package;
+in
 rustPlatform.buildRustPackage rec {
-  name = "hyprswitch";
-  version = "1.2.2";
+  name = meta.name;
+  version = meta.version;
 
   src = lib.cleanSource ./.;
 
@@ -29,8 +32,8 @@ rustPlatform.buildRustPackage rec {
   '';
 
   meta = with lib; {
-    description = "Graphical app switcher for hyprland";
-    homepage = "https://github.com/H3rmt/hyprswitch";
+    description = meta.description;
+    homepage = meta.repository;
     license = licenses.mit;
   };
 }

--- a/package.nix
+++ b/package.nix
@@ -30,9 +30,9 @@ in
       wrapProgram $out/bin/${name}
     '';
 
-    meta = with lib; {
+    meta = {
       description = package.description;
       homepage = package.repository;
-      license = licenses.mit;
+      license = package.license;
     };
   }


### PR DESCRIPTION
Creates a flake with which the app can be installed on NixOS. With this change, I've been able to successfully install and use hyprswitch on my NixOS machine.