### PR TITLE
Fix temporary value borrowing issue in gui.rs

### DIFF
--- a/src/daemon/gui/gui.rs
+++ b/src/daemon/gui/gui.rs
@@ -82,7 +82,8 @@ pub(super) fn update(
         };
 
         let workspace_fixed = Fixed::builder().width_request(width).height_request(height).build();
-        let title = if show_title && !workspace.name.trim().is_empty() { &workspace.name } else { &workspace.id.to_string() };
+        let id_string = workspace.id.to_string();
+        let title = if show_title && !workspace.name.trim().is_empty() { &workspace.name } else { &id_string };
         let workspace_frame = Frame::builder().label(title).label_xalign(0.5).child(&workspace_fixed).build();
         let workspace_frame_overlay = Overlay::builder().css_classes(vec!["workspace", "background"]).child(&workspace_frame).build();
 


### PR DESCRIPTION
Fixes #68

### Description
Fixed a Rust borrowing error (E0716) where a temporary string was being dropped while still borrowed. The issue occurred when converting workspace.id to a string in the title assignment.

### Changes
Modified `src/daemon/gui/gui.rs` to store the `workspace.id.to_string()` result in a separate variable before using it as a reference:

```rust
// Before
let title = if show_title && !workspace.name.trim().is_empty() { &workspace.name } else { &workspace.id.to_string() };

// After
let id_string = workspace.id.to_string();
let title = if show_title && !workspace.name.trim().is_empty() { &workspace.name } else { &id_string };