### PR TITLE
fix: set GUI layer namespace to `hyprswitch`

### DIFF
--- a/src/daemon/gui/windows/create.rs
+++ b/src/daemon/gui/windows/create.rs
@@ -50,6 +50,7 @@ pub fn create_windows(
             .default_width(10)
             .build();
         window.init_layer_shell();
+        window.set_namespace("hyprswitch");
         window.set_layer(Layer::Overlay);
         window.set_keyboard_mode(gtk4_layer_shell::KeyboardMode::None);
         window.set_monitor(monitor);


### PR DESCRIPTION
For example, with this you can create a layer rule for hyprswitch like this:
```
layerrule = blur, hyprswitch
```
The namespace is more identifiable than the default:
```
layerrule = blur, gtk4-layer-shell
```