### PR TITLE
Fix: typos in home manager configuration

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -74,7 +74,7 @@ All the settings are optional and can be found in the [module.nix](./nix/module.
       windows = {
         overview = {
           key = "super_l";
-          mod = super;
+          modifier = "super";
           launcher = {
             max_items = 6;
             plugins.websearch = {
@@ -87,7 +87,7 @@ All the settings are optional and can be found in the [module.nix](./nix/module.
             };
           };
         };
-        switcher.enable = false;
+        switch.enable = false;
       };
     };
   };


### PR DESCRIPTION
Found some more issues, immediate fix is trivial though.

close #275 