### PR TITLE
fix: apply user style with user priority

### DIFF
--- a/launcher-lib/src/css.rs
+++ b/launcher-lib/src/css.rs
@@ -1,6 +1,6 @@
 use gtk::gdk::Display;
 use gtk::{
-    CssProvider, STYLE_PROVIDER_PRIORITY_APPLICATION, glib, style_context_add_provider_for_display,
+    CssProvider, STYLE_PROVIDER_PRIORITY_USER, glib, style_context_add_provider_for_display,
 };
 
 pub fn get_css() {
@@ -9,6 +9,6 @@ pub fn get_css() {
     style_context_add_provider_for_display(
         &Display::default().expect("Could not connect to a display."),
         &provider_app,
-        STYLE_PROVIDER_PRIORITY_APPLICATION,
+        STYLE_PROVIDER_PRIORITY_USER,
     );
 }

--- a/windows-lib/src/css.rs
+++ b/windows-lib/src/css.rs
@@ -1,6 +1,6 @@
 use gtk::gdk::Display;
 use gtk::{
-    CssProvider, STYLE_PROVIDER_PRIORITY_APPLICATION, glib, style_context_add_provider_for_display,
+    CssProvider, STYLE_PROVIDER_PRIORITY_USER, glib, style_context_add_provider_for_display,
 };
 pub fn get_css() {
     let provider_app = CssProvider::new();
@@ -8,6 +8,6 @@ pub fn get_css() {
     style_context_add_provider_for_display(
         &Display::default().expect("Could not connect to a display."),
         &provider_app,
-        STYLE_PROVIDER_PRIORITY_APPLICATION,
+        STYLE_PROVIDER_PRIORITY_USER,
     );
 }


### PR DESCRIPTION
Hello, 

this pr changes the priority with which the user styles.css is loaded, since with `STYLE_PROVIDER_PRIORITY_APPLICATION` the existing gtk theme would have priority over styles.css:

before (styles.css not applied since gtk theme overrides it)
![2025-07-07-190446_hyprshot](https://github.com/user-attachments/assets/987ae891-5955-45ac-af01-f14ca31b45da)

after (styles.css takes priority)
![2025-07-07-190657_hyprshot](https://github.com/user-attachments/assets/48469c95-826b-4415-ac1f-a8ce6d86fbe9)
