### PR TITLE
Fix backward navigation not working on certain keyboard layouts

### DIFF
--- a/crates/hyprland-plugin/plugin/src/key-press.cpp
+++ b/crates/hyprland-plugin/plugin/src/key-press.cpp
@@ -116,7 +116,7 @@ void onKeyPress(const std::unordered_map<std::string, std::any> &data, SCallback
                     sendStringToHyprshellSocket(HYPRSHELL_OPEN_SWITCH_REVERSE);
                 }
             }
-            if (keysym == XKB_KEY_grave) {
+            if (keysym == XKB_KEY_grave || keysym == XKB_KEY_dead_grave) {
                 if ((HYPRSHELL_SWTICH_XKB_MOD_L == XKB_KEY_Alt_L && altActive) ||
                     (HYPRSHELL_SWTICH_XKB_MOD_L == XKB_KEY_Super_L && superActive) ||
                     (HYPRSHELL_SWTICH_XKB_MOD_L == XKB_KEY_Control_L && ctrlActive)

--- a/crates/launcher-lib/src/create.rs
+++ b/crates/launcher-lib/src/create.rs
@@ -178,7 +178,7 @@ fn handle_key(
                 .warn_details("unable to send");
             Propagation::Stop
         }
-        (_, Key::ISO_Left_Tab | Key::grave) => {
+        (_, Key::ISO_Left_Tab | Key::grave | Key::dead_grave) => {
             event_sender
                 .send_blocking(TransferType::SwitchOverview(SwitchOverviewConfig {
                     workspace: false,

--- a/crates/windows-lib/src/switch/create.rs
+++ b/crates/windows-lib/src/switch/create.rs
@@ -103,7 +103,7 @@ fn handle_key(key: Key, event_sender: &Sender<TransferType>) -> Propagation {
                 .warn_details("unable to send");
             Propagation::Stop
         }
-        Key::ISO_Left_Tab | Key::grave => {
+        Key::ISO_Left_Tab | Key::grave | Key::dead_grave => {
             event_sender
                 .send_blocking(TransferType::SwitchSwitch(SwitchSwitchConfig {
                     reverse: true,


### PR DESCRIPTION
This PR adds support for the key combination Alt + dead_grave in addition to Alt + grave.

On some keyboard layouts, the grave key emits the dead_grave keycode instead of grave, which was previously not recognized by Hyprshell. This change ensures consistent behavior across different keyboard layouts.